### PR TITLE
Fixed what I believe is a typo in SSID handling during packet creation.

### DIFF
--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -537,7 +537,7 @@ size_t AFSK::Packet::appendCallsign(const char *callsign, uint8_t ssid, bool fin
   if(final) {
     ssidField |= 0b01100001;
   } else {
-    ssidField |= 0b11100000;
+    ssidField |= 0b01100000;
   }
   appendFCS(ssidField);
 }


### PR DESCRIPTION
Doing a PR instead of merging myself as I want a second set of eyes on this to be sure I'm not missing something. I believe this line was a typo.

The only difference between a normal callsign and a final one should be the LSB. In the if(final) case, the |= is setting the LSB, and or'ing with the character '0' as it should be. In the else case, the MSB seems to be set which is giving an improper value to this byte.

In my testing it seemed that for *most* values of SSID, the packets were being decoded properly which is why we haven't run into this, however I ran into it not working for SSID=9, and ran across this. Technically the other values are still wrong, but somehow were working, but 9 was not. Not sure why.